### PR TITLE
Change abs to labs in vector-aux.c

### DIFF
--- a/packages/base/src/Internal/C/vector-aux.c
+++ b/packages/base/src/Internal/C/vector-aux.c
@@ -571,7 +571,7 @@ int mapL(int code, KLVEC(x), LVEC(r)) {
     int k;
     REQUIRES(xn == rn,BAD_SIZE);
     switch (code) {
-        OP(3,abs)
+        OP(3,labs)
         OP(15,sign)
         default: ERROR(BAD_CODE);
     }


### PR DESCRIPTION
I can't tell if this is necessarily wanted, here, but likely so. Without it, it does not build for me, as a '-Werror' switch causes the build to fail. This small fix seems correct.